### PR TITLE
fix: cp eslintrc.js to es dir;fix problem caused by process.cwd, repl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "zfer": "ts-node src/zfer.ts",
-    "build": "tsc"
+    "build": "tsc && cp ./src/lint/.eslintrc.js ./es/lint/.eslintrc.js"
   },
   "bin": {
     "zfer": "es/zfer.js"

--- a/src/zfer.ts
+++ b/src/zfer.ts
@@ -3,14 +3,18 @@
 import { program, Option, Command } from 'commander';
 import fs from 'fs';
 import path from 'path';
-const cwd = process.cwd();
 const PKG_NAME = 'package.json';
 import lint from './lint';
 import { compose } from './utils';
 
 const toString = (buffer: Buffer) => buffer.toString();
 const resolveCwd = (cwd: string) => (filename: string) => path.resolve(cwd, filename);
-const getPkgByFilename = compose<string, {version: string}>(JSON.parse, toString, fs.readFileSync, resolveCwd(cwd));
+const getPkgByFilename = compose<string, {version: string}>(
+  JSON.parse,
+  toString,
+  fs.readFileSync,
+  resolveCwd(path.resolve(__dirname, '../'))
+);
 const pkg = getPkgByFilename(PKG_NAME);
 
 const VERSION = pkg.version;


### PR DESCRIPTION
fix: cp eslintrc.js to es dir;fix problem caused by process.cwd, replaced by __dirname

- build脚本新增cp指令，解决相对路径问题;
- 结局我工作区路径问题，cwd与__dirname的区别